### PR TITLE
Configure GH Actions for tests/lints.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,64 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -41,7 +41,7 @@ async fn main() -> shotgun_rs::Result<()> {
         None,
         None,
     )
-        .expect("SG Client");
+    .expect("SG Client");
 
     let _sess = sg.authenticate_user(&username, &password).await?;
     println!("\nLogin Succeeded!");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,7 @@ impl Shotgun {
                 ("username", username),
                 ("password", password),
             ])
-                .await?,
+            .await?,
         ))
     }
 
@@ -289,7 +289,7 @@ impl Shotgun {
     /// `ShotgunError::BadClientConfig` if either is missing.
     pub async fn authenticate_script(&self) -> Result<Session<'_>> {
         if let (Some(script_name), Some(script_key)) =
-        (self.script_name.as_ref(), self.script_key.as_ref())
+            (self.script_name.as_ref(), self.script_key.as_ref())
         {
             Ok(Session::new(
                 self,
@@ -298,7 +298,7 @@ impl Shotgun {
                     ("client_id", &script_name),
                     ("client_secret", &script_key),
                 ])
-                    .await?,
+                .await?,
             ))
         } else {
             Err(ShotgunError::BadClientConfig(
@@ -314,7 +314,7 @@ impl Shotgun {
     /// `ShotgunError::BadClientConfig` if either is missing.
     pub async fn authenticate_script_as_user(&self, login: &str) -> Result<Session<'_>> {
         if let (Some(script_name), Some(script_key)) =
-        (self.script_name.as_ref(), self.script_key.as_ref())
+            (self.script_name.as_ref(), self.script_key.as_ref())
         {
             Ok(Session::new(
                 self,
@@ -324,7 +324,7 @@ impl Shotgun {
                     ("client_secret", &script_key),
                     ("scope", &format!("sudo_as_login:{}", login)),
                 ])
-                    .await?,
+                .await?,
             ))
         } else {
             Err(ShotgunError::BadClientConfig(
@@ -336,8 +336,8 @@ impl Shotgun {
     /// Provides version information about the Shotgun server and the REST API.
     /// Does not require authentication
     pub async fn info<D: 'static>(&self) -> Result<D>
-        where
-            D: DeserializeOwned,
+    where
+        D: DeserializeOwned,
     {
         let req = self
             .client
@@ -370,8 +370,8 @@ fn contains_errors(value: &Value) -> bool {
 /// Error with some details about what went wrong if your shape doesn't fit, or any of that other
 /// stuff happened.
 async fn handle_response<D>(resp: Response) -> Result<D>
-    where
-        D: DeserializeOwned,
+where
+    D: DeserializeOwned,
 {
     let bytes = resp.bytes().await?;
     // There are three (3) potential failure modes here:
@@ -426,7 +426,7 @@ pub enum ShotgunError {
     BadClientConfig(String),
 
     #[fail(
-    display = "Invalid Filters: expected `filters` key to be array or object; was neither."
+        display = "Invalid Filters: expected `filters` key to be array or object; was neither."
     )]
     InvalidFilters,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,8 +295,8 @@ impl Shotgun {
                 self,
                 self.authenticate(&[
                     ("grant_type", "client_credentials"),
-                    ("client_id", &script_name),
-                    ("client_secret", &script_key),
+                    ("client_id", script_name),
+                    ("client_secret", script_key),
                 ])
                 .await?,
             ))
@@ -320,8 +320,8 @@ impl Shotgun {
                 self,
                 self.authenticate(&[
                     ("grant_type", "client_credentials"),
-                    ("client_id", &script_name),
-                    ("client_secret", &script_key),
+                    ("client_id", script_name),
+                    ("client_secret", script_key),
                     ("scope", &format!("sudo_as_login:{}", login)),
                 ])
                 .await?,
@@ -352,7 +352,7 @@ impl Shotgun {
 fn contains_errors(value: &Value) -> bool {
     value
         .as_object()
-        .and_then(|obj| Some(obj.contains_key("errors")))
+        .map(|obj| obj.contains_key("errors"))
         .unwrap_or(false)
 }
 


### PR DESCRIPTION
This configures base checks for the project including the tests, style, and lints (via clippy). Additional revs follow to fixup the various failing checks.

The original scope for #10 hoped to get coverage and integration tests happening, but IIRC there are some hassles around permissions and secrets with GitHub actions that mean added complexity for running them in PRs coming from forks.

Since these base checks are low-hanging fruit and still very useful for the work we already have ticketed out, I am looking to defer the coverage/integration jobs until a later date to prioritize having these in place.

fixes #10