### PR TITLE
Treat examples in README.md as doctests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ wiremock = "0.4.0-alpha.2"
 actix-multipart = "0.3.0"
 actix-web = "3.3.2"
 approx = "0.4.0"
+doc-comment = "0.3.3"
 
 [features]
 default = ["native-tls"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,6 +485,12 @@ pub struct TokenResponse {
     pub refresh_token: String,
 }
 
+#[cfg(doctest)]
+mod readme_tests {
+    use doc_comment::doctest;
+    doctest!("../README.md");
+}
+
 #[cfg(test)]
 mod mock_tests {
     use super::*;


### PR DESCRIPTION
It's easy to maintain the examples in our docstrings since they are automatically checked during `cargo test`. The examples in the README.md are often forgotten and lag behind.

To help prevent this from happening in the future, this PR adds the [doc-comment](https://crates.io/crates/doc-comment) and uses it to treat the entire README content as if it were a giant docstring.

A follow-up rev updates the readme content so the new "tests" pass. Mostly this was achieved by lightly modifying the docstrings in `lib.rs`.

Fixes #9