### PR TITLE
Re-export the entire reqwest crate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 ### Breaking Changes
 
 - `Shotgun::schema_field_create()` no longer accepts a `CreateFieldRequest`.
-  Instead it takes separate `data_type` and `properties` parameters.
+  Instead, it takes separate `data_type` and `properties` parameters.
 - `Shotgun::schema_field_update()` no longer accepts an `UpdateFieldRequest`.
-  Instead it takes separate `properties` and `project_id` parameters.
+  Instead, it takes separate `properties` and `project_id` parameters.
 - `ShotgunError` was renamed `Error`.
+- `Client` and `Certificate` are no longer re-exported from the crate root.
+  Instead, the entire `reqwest` crate is re-exported under the `transport` module.
 
 #### Sessions
 


### PR DESCRIPTION
There are many types involved in configuring a reqwest client, so rather
than try to cherry-pick the stuff we think will be useful, it might be
better to just re-export the whole thing.

This diff does the re-export under a `transport` module, which could be
useful in the future if we end up offering support for different http clients.

In that situation, there'd be a lot of conditional compilation/feature
checking so we'd want the option to move all that noise into a separate
file.

Fixes #7