### PR TITLE
Change select references to "Shotgun" to instead use "ShotGrid."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - `ShotgunError` was renamed `Error`.
 - `Client` and `Certificate` are no longer re-exported from the crate root.
   Instead, the entire `reqwest` crate is re-exported under the `transport` module.
+- The name of the client struct `Shotgun` is now known as `Client`.
+- The `Shotgun::with_client()` method is now known as `Client::with_transport()`.
 
 #### Sessions
 
@@ -48,13 +50,13 @@ let _ = sg.search(&norman_token, "Task", /* ...*/)?;
 As of v0.9:
 
 ```rust
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 
 let server = "https://my-shotgun.example.com";
 let script_name = "my-api-admin";
 let secret = "********";
 
-let sg = Shotgun::new(server.to_string(), Some(script_name), Some(secret))?;
+let sg = Client::new(server.to_string(), Some(script_name), Some(secret))?;
 
 let admin_session = sg.authenticate_script()?;
 let _ = admin_session.create("Task", /* ... */)?;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "shotgun-rs"
+name = "shotgrid-rs"
 version = "0.9.0-alpha"
 authors = [
     "Owen Nelson <onelson@laika.com>",
@@ -45,7 +45,7 @@ rustls = ["reqwest/rustls-tls"]
 # Enable this to allow `cargo test` to run the integration tests.
 # The integration tests also depend on having the following env vars set:
 #
-# - `TEST_SG_SERVER`, the shotgun server to connect to.
+# - `TEST_SG_SERVER`, the ShotGrid server to connect to.
 # - `TEST_SG_SCRIPT_NAME`, the name of an ApiUser to connect as.
 # - `TEST_SG_SCRIPT_KEY`, the API key to go with the name.
 # - `TEST_SG_HUMAN_USER_LOGIN`, certain tests require a `HumanUser` so this is

--- a/README.md
+++ b/README.md
@@ -1,23 +1,21 @@
-# shotgun-rs
+# shotgrid-rs
 
-`shotgun-rs` is a REST API client for [Autodesk Shotgun][shotgun] built with
-[reqwest] and [serde_json].
-
-## Usage
+`shotgrid-rs` is a REST API client for [Autodesk ShotGrid][shotgrid] (formerly
+_Shotgun_) built with [reqwest] and [serde_json].
 
 ## Usage
 
-The general pattern of usage starts with a `shotgun_rs::Shotgun` client.
+The general pattern of usage starts with a `shotgrid_rs::Client`.
 
 ```rust,no_run
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
-    let server = "https://my-shotgun.example.com";
+async fn main() -> shotgrid_rs::Result<()> {
+    let server = "https://my-shotgrid.example.com";
     let script_name = "my-api-user";
     let script_key = "********";
-    let sg = Shotgun::new(server.to_string(), Some(script_name), Some(script_key))?;
+    let sg = Client::new(server.to_string(), Some(script_name), Some(script_key))?;
     // ...
     Ok(())
 }
@@ -27,14 +25,14 @@ Once your client is in hand, you'd use one of the authentication methods to
 get a `Session`.
 
 ```rust,no_run
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
-    let server = "https://my-shotgun.example.com";
+async fn main() -> shotgrid_rs::Result<()> {
+    let server = "https://my-shotgrid.example.com";
     let script_name = "my-api-user";
     let script_key = "********";
-    let sg = Shotgun::new(server.to_string(), Some(script_name), Some(script_key))?;
+    let sg = Client::new(server.to_string(), Some(script_name), Some(script_key))?;
     // Authenticates using the script name and script key held by the client.
     let session = sg.authenticate_script().await?;
     // ...
@@ -43,7 +41,7 @@ async fn main() -> shotgun_rs::Result<()> {
 ```
 
 From there, you can use that `Session` to invoke the various query
-methods, either to use Shotgun's rich filter API to find
+methods, either to use ShotGrid's rich filter API to find
 records, or to create/update records.
 
 For operations where the schema of the response is *flexible* (based on the
@@ -59,9 +57,9 @@ the response's "links" key).
 
 ```rust,no_run
 use serde_derive::Deserialize;
-use shotgun_rs::types::{PaginationLinks, ResourceArrayResponse, SelfLink};
-use shotgun_rs::Shotgun;
-use shotgun_rs::filters;
+use shotgrid_rs::types::{PaginationLinks, ResourceArrayResponse, SelfLink};
+use shotgrid_rs::Client;
+use shotgrid_rs::filters;
 
 
 /// This struct should match the return fields specified for the search.
@@ -81,13 +79,13 @@ struct Project {
 
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
 
-    let server = "https://my-shotgun.example.com";
+    let server = "https://my-shotgrid.example.com";
     let script_name = "my-api-user";
     let script_key = "********";
 
-    let sg = Shotgun::new(server.to_string(), Some(script_name), Some(script_key))?;
+    let sg = Client::new(server.to_string(), Some(script_name), Some(script_key))?;
 
     let session = sg.authenticate_script().await?;
 
@@ -117,7 +115,7 @@ the value yourself.
 
 ## Logging
 
-The `shotgun_rs` crate offers some logging, though most of it relates to the
+The `shotgrid_rs` crate offers some logging, though most of it relates to the
 internals of the library itself.
 
 If you're interested in logging the HTTP-transport layer, since we're using
@@ -136,7 +134,7 @@ $ cargo test
 ```
 
 In addition to the unit tests, there is a set of end-to-end tests (ie, requires
-a live Shotgun server) which can be run by enabling the `integration-tests`
+a live ShotGrid server) which can be run by enabling the `integration-tests`
 feature:
 
 ```text
@@ -145,7 +143,7 @@ $ cargo test --features integration-tests
 
 The integration tests require a set of environment vars to be set in order to pass:
 
-- `TEST_SG_SERVER`, the shotgun server to connect to.
+- `TEST_SG_SERVER`, the ShotGrid server to connect to.
 - `TEST_SG_SCRIPT_NAME`, the name of an ApiUser to connect as.
 - `TEST_SG_SCRIPT_KEY`, the API key to go with the name.
 - `TEST_SG_HUMAN_USER_LOGIN`, certain tests require a `HumanUser` so this is
@@ -155,9 +153,9 @@ The integration tests require a set of environment vars to be set in order to pa
 At the time of writing, these tests read but don't write. This may change in the
 future so please take care when setting these vars.
 
-If possible you may want to isolate your test runs to a secondary shotgun server
-(if you have a spare for development), or at the very least select a "test"
-project.
+If possible you may want to isolate your test runs to a secondary ShotGrid
+server (if you have a spare for development), or at the very least select a
+"test" project.
 
 ## License
 
@@ -176,7 +174,7 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
-[shotgun]: https://www.shotgunsoftware.com/
+[shotgrid]: https://www.shotgridsoftware.com/
 [reqwest]: https://crates.io/crates/reqwest
 [serde]: https://crates.io/crates/serde
 [serde_json]: https://crates.io/crates/serde_json

--- a/examples/delete-entity.rs
+++ b/examples/delete-entity.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
+//! loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -22,11 +22,11 @@
 //! $ cargo run --example delete-entity task 123456
 //! ```
 
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -40,7 +40,7 @@ async fn main() -> shotgun_rs::Result<()> {
 
     println!("Attempting to delete {:?} {:?}", entity, entity_id);
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
 
     let session = sg.authenticate_script().await?;
 

--- a/examples/entity-activity-stream-read.rs
+++ b/examples/entity-activity-stream-read.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -22,11 +22,11 @@
 //! $ cargo run --example entity-activity-stream-read task 123456[task-id]
 //! ```
 
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -43,7 +43,7 @@ async fn main() -> shotgun_rs::Result<()> {
         entity_type, entity_id
     );
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let sess = sg.authenticate_script().await?;
 
     let resp = sess

--- a/examples/entity-file-field-read.rs
+++ b/examples/entity-file-field-read.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -22,12 +22,12 @@
 //! $ cargo run --example entity-file-field-read asset 123456 image [original (alt)] [bytes=0-100 (range)]
 //! ```
 
-use shotgun_rs::types::{AltImages, FieldHashResponse};
-use shotgun_rs::Shotgun;
+use shotgrid_rs::types::{AltImages, FieldHashResponse};
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -47,7 +47,7 @@ async fn main() -> shotgun_rs::Result<()> {
         field_name, entity_type, entity_id, alt, range
     );
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let sess = sg.authenticate_script().await?;
 
     let alt_option: Option<AltImages> = alt.map(|val| match val.as_str() {

--- a/examples/entity-follow-update.rs
+++ b/examples/entity-follow-update.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -23,12 +23,12 @@
 //! $ cargo run --example entity-follow-update 1023 Task 123456
 //! ```
 
-use shotgun_rs::types::EntityIdentifier;
-use shotgun_rs::Shotgun;
+use shotgrid_rs::types::EntityIdentifier;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -44,7 +44,7 @@ async fn main() -> shotgun_rs::Result<()> {
         user_id, entity_type, entity_id
     );
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
 
     let session = sg.authenticate_script().await?;
 

--- a/examples/entity-followers-read.rs
+++ b/examples/entity-followers-read.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -23,11 +23,11 @@
 //! ```
 
 use serde_json::Value;
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -41,7 +41,7 @@ async fn main() -> shotgun_rs::Result<()> {
         entity, entity_id
     );
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let sess = sg.authenticate_script().await?;
     let resp: Value = sess
         .entity_followers_read(&entity.unwrap(), entity_id.unwrap())

--- a/examples/entity-relationship-read.rs
+++ b/examples/entity-relationship-read.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -24,11 +24,11 @@
 //!
 
 use serde_json::Value;
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
     let script_name = env::var("SG_SCRIPT_NAME").expect("SG_SCRIPT_NAME is required var.");
@@ -43,7 +43,7 @@ async fn main() -> shotgun_rs::Result<()> {
         entity, entity_id, related_field
     );
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let sess = sg.authenticate_script().await?;
 
     let resp: Value = sess

--- a/examples/entity-unfollow-update.rs
+++ b/examples/entity-unfollow-update.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -22,11 +22,11 @@
 //! $ cargo run --example entity-unfollow-update 1023 task 123456
 //! ```
 
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -42,7 +42,7 @@ async fn main() -> shotgun_rs::Result<()> {
         user_id, entity_type, entity_id
     );
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let session = sg.authenticate_script().await?;
 
     session

--- a/examples/info.rs
+++ b/examples/info.rs
@@ -1,16 +1,16 @@
-//! Small example program that prints out the shotgun information and the REST API information.
+//! Small example program that prints out the ShotGrid server information.
 //!
 //! For this to work you must set 1 env - this does not require authentication
 //! vars, `SG_SERVER`
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -23,14 +23,14 @@
 //! ```
 
 use serde_json::Value;
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
-    let sg = Shotgun::new(server, None, None).expect("SG Client");
+    let sg = Client::new(server, None, None).expect("SG Client");
     let resp: Value = sg.info().await?;
 
     for key in resp["data"].as_object().expect("response decode").keys() {

--- a/examples/list-projects.rs
+++ b/examples/list-projects.rs
@@ -1,14 +1,14 @@
 //! Small example program that prints out a table of projects. For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -24,19 +24,19 @@
 extern crate prettytable;
 use prettytable::{format, Table};
 use serde_json::Value;
-use shotgun_rs::filters;
-use shotgun_rs::Shotgun;
+use shotgrid_rs::filters;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
     let script_name = env::var("SG_SCRIPT_NAME").expect("SG_SCRIPT_NAME is required var.");
     let script_key = env::var("SG_SCRIPT_KEY").expect("SG_SCRIPT_KEY is required var.");
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let sess = sg.authenticate_script().await?;
 
     let resp: Value = sess

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -1,14 +1,13 @@
-//! Small example program that runs a login using a username and password and prints out the
-//! resulting response from shotgun.
+//! Small example program that runs a login using a username and password.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -20,12 +19,12 @@
 //! $ cargo run --example login -- <username>
 //! ```
 
-extern crate shotgun_rs;
-use shotgun_rs::Shotgun;
+extern crate shotgrid_rs;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     // Get a username from argv.
@@ -36,7 +35,7 @@ async fn main() -> shotgun_rs::Result<()> {
     // Prompt the user for a password.
     let password = rpassword::read_password_from_tty(Some("Password: ")).unwrap();
 
-    let sg = Shotgun::new(
+    let sg = Client::new(
         env::var("SG_SERVER").expect("SG_SERVER is required."),
         None,
         None,
@@ -44,6 +43,6 @@ async fn main() -> shotgun_rs::Result<()> {
     .expect("SG Client");
 
     let _sess = sg.authenticate_user(&username, &password).await?;
-    println!("\nLogin Succeeded!");
+    println!("Login Succeeded!");
     Ok(())
 }

--- a/examples/preferences-read.rs
+++ b/examples/preferences-read.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -23,18 +23,18 @@
 //! ```
 
 use serde_json::Value;
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
     let script_name = env::var("SG_SCRIPT_NAME").expect("SG_SCRIPT_NAME is required var.");
     let script_key = env::var("SG_SCRIPT_KEY").expect("SG_SCRIPT_KEY is required var.");
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let session = sg.authenticate_script().await?;
     let resp: Value = session.preferences_read().await?;
 

--- a/examples/project-last-accessed-update.rs
+++ b/examples/project-last-accessed-update.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -22,12 +22,12 @@
 //! $ cargo run --example project-last-accessed-update 123(project id) 1048 (user id)
 //! ```
 
-use shotgun_rs::types::ProjectAccessUpdateResponse;
-use shotgun_rs::Shotgun;
+use shotgrid_rs::types::ProjectAccessUpdateResponse;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -46,7 +46,7 @@ async fn main() -> shotgun_rs::Result<()> {
         project_id, user_id
     );
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG client");
     let sess = sg.authenticate_script().await?;
 
     let resp: ProjectAccessUpdateResponse = sess

--- a/examples/read.rs
+++ b/examples/read.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -23,11 +23,11 @@
 //! ```
 
 use serde_json::Value;
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -43,7 +43,7 @@ async fn main() -> shotgun_rs::Result<()> {
         entity, entity_id, fields
     );
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let sess = sg.authenticate_script().await?;
 
     let resp: Value = sess

--- a/examples/revive-entity.rs
+++ b/examples/revive-entity.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -23,11 +23,11 @@
 //! ```
 
 use serde_json::Value;
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -40,7 +40,7 @@ async fn main() -> shotgun_rs::Result<()> {
         .and_then(|s| Some(s.parse().expect("Entity ID")));
 
     println!("Attempting to revive {:?} {:?}", entity, entity_id);
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let session = sg.authenticate_script().await?;
 
     let resp: Value = session.revive(&entity.unwrap(), entity_id.unwrap()).await?;

--- a/examples/schema-entity-read.rs
+++ b/examples/schema-entity-read.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -26,11 +26,11 @@
 //! $ cargo run --example schema-entity-read [project_id] 'custom_non_project_entity_01'
 //! ```
 
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
     let script_name = env::var("SG_SCRIPT_NAME").expect("SG_SCRIPT_NAME is required var.");
@@ -41,7 +41,7 @@ async fn main() -> shotgun_rs::Result<()> {
     let entity: Option<String> = env::args().nth(2);
 
     println!("Attempting to read {:?}", entity);
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
 
     let sess = sg.authenticate_script().await?;
 

--- a/examples/schema-field-create.rs
+++ b/examples/schema-field-create.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -24,16 +24,16 @@
 //!
 //! For the sake of brevity, this example is only going to create properties with a data type of text.
 //! The property_name has to be one of the values underneath schema field record - name, description, etc:
-//! <https://developer.shotgunsoftware.com/rest-api/#schemaschemafieldrecord>
+//! <https://developer.shotgridsoftware.com/rest-api/#schemaschemafieldrecord>
 //! Also listed in the struct types/SchemaFieldRecord
 //!
 
-use shotgun_rs::types::FieldDataType;
-use shotgun_rs::Shotgun;
+use shotgrid_rs::types::FieldDataType;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -49,7 +49,7 @@ async fn main() -> shotgun_rs::Result<()> {
         property_name, entity_type, property_value
     );
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let sess = sg.authenticate_script().await?;
 
     let resp = sess

--- a/examples/schema-field-delete.rs
+++ b/examples/schema-field-delete.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -22,11 +22,11 @@
 //! $ cargo run --example schema-field-delete task sg_field_name_to_delete
 //! ```
 
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -41,7 +41,7 @@ async fn main() -> shotgun_rs::Result<()> {
         field_name, entity_type
     );
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
 
     let session = sg.authenticate_script().await?;
 

--- a/examples/schema-field-read.rs
+++ b/examples/schema-field-read.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -22,11 +22,11 @@
 //! $ cargo run --example schema-field-read [project_id] 'task' 'sg_status_list'
 //! ```
 
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -41,7 +41,7 @@ async fn main() -> shotgun_rs::Result<()> {
 
     println!("Attempting to read {:?} on {:?}", field_name, entity);
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
 
     let sess = sg.authenticate_script().await?;
 

--- a/examples/schema-field-revive.rs
+++ b/examples/schema-field-revive.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -22,11 +22,11 @@
 //! $ cargo run --example schema-field-revive task sg_hello
 //! ```
 
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -41,7 +41,7 @@ async fn main() -> shotgun_rs::Result<()> {
         field_name, entity_type
     );
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let session = sg.authenticate_script().await?;
     session
         .schema_field_revive(&entity_type.unwrap(), &field_name.unwrap())

--- a/examples/schema-field-update.rs
+++ b/examples/schema-field-update.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -22,11 +22,11 @@
 //! $ cargo run --example schema-field-update task sg_hello name hello_world
 //! ```
 
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -40,7 +40,7 @@ async fn main() -> shotgun_rs::Result<()> {
 
     println!("Attempting to update {} on {}", field_name, entity_type);
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let sess = sg.authenticate_script().await?;
     let resp = sess
         .schema_field_update(

--- a/examples/schema-fields-read.rs
+++ b/examples/schema-fields-read.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -22,11 +22,11 @@
 //! $ cargo run --example schema-fields-read [project_id] 'task'
 //! ```
 
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -39,7 +39,7 @@ async fn main() -> shotgun_rs::Result<()> {
 
     println!("Attempting to read: {:?}", entity);
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
 
     let sess = sg.authenticate_script().await?;
 

--- a/examples/schema-read.rs
+++ b/examples/schema-read.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -23,11 +23,11 @@
 //! ```
 
 use serde_json::Value;
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -36,7 +36,7 @@ async fn main() -> shotgun_rs::Result<()> {
 
     let project_id: Option<i32> = env::args().nth(1).map(|s| s.parse().expect("proj id"));
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let session = sg.authenticate_script().await?;
 
     let resp: Value = session.schema_read(project_id).await?;

--- a/examples/summarize-child-tasks.rs
+++ b/examples/summarize-child-tasks.rs
@@ -1,14 +1,14 @@
 //! Small example program that prints out a table of projects. For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -20,13 +20,13 @@
 //! $ cargo run --example summarize-child-tasks <task ids...>
 //! ```
 
-use shotgun_rs::filters::{self, field};
-use shotgun_rs::types::{GroupingType, SummaryFieldType};
-use shotgun_rs::Shotgun;
+use shotgrid_rs::filters::{self, field};
+use shotgrid_rs::types::{GroupingType, SummaryFieldType};
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -42,7 +42,7 @@ async fn main() -> shotgun_rs::Result<()> {
         panic!("must specify one or more parent task ids");
     }
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let sess = sg.authenticate_script().await?;
 
     let resp = sess

--- a/examples/summarize-project-assets.rs
+++ b/examples/summarize-project-assets.rs
@@ -1,14 +1,14 @@
 //! Small example program that prints out a table of projects. For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -20,13 +20,13 @@
 //! $ cargo run --example summarize-project-assets <project id>
 //! ```
 
-use shotgun_rs::filters::{self, field, EntityRef};
-use shotgun_rs::types::{GroupingDirection, GroupingType, SummaryFieldType};
-use shotgun_rs::Shotgun;
+use shotgrid_rs::filters::{self, field, EntityRef};
+use shotgrid_rs::types::{GroupingDirection, GroupingType, SummaryFieldType};
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -39,7 +39,7 @@ async fn main() -> shotgun_rs::Result<()> {
         .parse()
         .expect("invalid project id");
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let sess = sg.authenticate_script().await?;
 
     let summary = sess

--- a/examples/text-search.rs
+++ b/examples/text-search.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -19,16 +19,16 @@
 //! Usage:
 //!
 //! ```text
-//! $ cargo run --example text-search <shotgun login to search as> <asset name to search for> [limit]
+//! $ cargo run --example text-search <ShotGrid login to search as> <asset name to search for> [limit]
 //! ```
 
 use serde_json::Value;
-use shotgun_rs::filters::{self, field};
-use shotgun_rs::Shotgun;
+use shotgrid_rs::filters::{self, field};
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -41,7 +41,7 @@ async fn main() -> shotgun_rs::Result<()> {
         .nth(3)
         .map(|s| s.parse().expect("limit must be a number"));
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
 
     let sess = sg.authenticate_script_as_user(&login).await?;
 

--- a/examples/thread-contents-read.rs
+++ b/examples/thread-contents-read.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -24,12 +24,12 @@
 //!
 
 use serde_json::Value;
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::collections::HashMap;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
     let script_name = env::var("SG_SCRIPT_NAME").expect("SG_SCRIPT_NAME is required var.");
@@ -39,7 +39,7 @@ async fn main() -> shotgun_rs::Result<()> {
 
     println!("Attempting to read note: {:?}", note_id);
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let sess = sg.authenticate_script().await?;
     let mut fields: HashMap<String, String> = HashMap::new();
 

--- a/examples/update-entity.rs
+++ b/examples/update-entity.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -24,11 +24,11 @@
 //! This example only does string or int types for the value.
 
 use serde_json::{json, Value};
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -43,7 +43,7 @@ async fn main() -> shotgun_rs::Result<()> {
     let value: Option<String> = env::args().nth(4);
     let return_fields: Option<String> = env::args().nth(5);
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let sess = sg.authenticate_script().await?;
 
     let data: Value = json!({

--- a/examples/upload.rs
+++ b/examples/upload.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -22,12 +22,12 @@
 //! $ cargo run --example upload note 12345 tester path/to/file.ext [optional display name]
 //! ```
 
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 use std::path::PathBuf;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER");
@@ -42,7 +42,7 @@ async fn main() -> shotgun_rs::Result<()> {
     let file_path: PathBuf = env::args().nth(3).expect("File Path").into();
     let display_name = env::args().nth(4);
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let session = sg.authenticate_script().await?;
     let fh = std::fs::OpenOptions::new()
         .read(true)

--- a/examples/user-follows-read.rs
+++ b/examples/user-follows-read.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -23,11 +23,11 @@
 //! ```
 
 use serde_json::Value;
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -36,7 +36,7 @@ async fn main() -> shotgun_rs::Result<()> {
 
     let user_id: Option<i32> = env::args().nth(1).map(|s| s.parse().expect("User ID"));
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let session = sg.authenticate_script().await?;
     let resp: Value = session.user_follows_read(user_id.unwrap()).await?;
 

--- a/examples/work-day-rules-read.rs
+++ b/examples/work-day-rules-read.rs
@@ -3,14 +3,14 @@
 //! For this to work you must set 3 env
 //! vars, `SG_SERVER`, `SG_SCRIPT_NAME`, and `SG_SCRIPT_KEY`.
 //!
-//! Set the `SG_SERVER` environment variable to the url for your shotgun server, eg:
+//! Set the `SG_SERVER` environment variable to the url for your ShotGrid server, eg:
 //!
 //! ```text
-//! export SG_SERVER=https://shotgun.example.com
+//! export SG_SERVER=https://shotgrid.example.com
 //! ```
 //!
-//! `shotgun_rs` also looks at the `CA_BUNDLE` environment variable for when you need a custom CA
-//! loaded to access your shotgun server, for example:
+//! `shotgrid_rs` also looks at the `CA_BUNDLE` environment variable for when
+//! you need a custom CA loaded to access your ShotGrid server, for example:
 //!
 //! ```text
 //! export CA_BUNDLE=/etc/ssl/my-ca-certs.crt
@@ -23,11 +23,11 @@
 //! ```
 
 use serde_json::Value;
-use shotgun_rs::Shotgun;
+use shotgrid_rs::Client;
 use std::env;
 
 #[tokio::main]
-async fn main() -> shotgun_rs::Result<()> {
+async fn main() -> shotgrid_rs::Result<()> {
     dotenv::dotenv().ok();
 
     let server = env::var("SG_SERVER").expect("SG_SERVER is required var.");
@@ -39,7 +39,7 @@ async fn main() -> shotgun_rs::Result<()> {
     let user_id: Option<i32> = env::args().nth(3).map(|s| s.parse().expect("User ID"));
     let project_id: Option<i32> = env::args().nth(4).map(|s| s.parse().expect("Project ID"));
 
-    let sg = Shotgun::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
+    let sg = Client::new(server, Some(&script_name), Some(&script_key)).expect("SG Client");
     let sess = sg.authenticate_script().await?;
     let resp: Value = sess
         .work_days_rules_read(

--- a/src/entity_relationship_read.rs
+++ b/src/entity_relationship_read.rs
@@ -42,7 +42,7 @@ impl<'a> EntityRelationshipReadReqBuilder<'a> {
     {
         let (sg, token) = self.session.get_sg().await?;
         let mut req = sg
-            .client
+            .http
             .get(&format!(
                 "{}/api/v1/entity/{}/{}/relationships/{}",
                 sg.sg_server, self.entity, self.entity_id, self.related_field

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -4,7 +4,7 @@
 //! Each of these functions will ultimately produce a [`FinalizedFilters`], which
 //! can be then handed off to a query method.
 //!
-//! Filters play a role in a number of places in the Shotgun API including:
+//! Filters play a role in a number of places in the ShotGrid API including:
 //!
 //! - [`Session::search()`](`crate::session::Session::search()`)
 //! - [`Session::summarize()`](`crate::session::Session::summarize()`)
@@ -20,7 +20,7 @@
 //! > for [`Field`] (the return of the [`field()`] function).
 //!
 //! ```
-//! use shotgun_rs::filters::{field, EntityRef};
+//! use shotgrid_rs::filters::{field, EntityRef};
 //!
 //! let project = field("project").is(EntityRef::new("Project", 123));
 //! let created_by = field("created_by.HumanUser.id").in_(&[456, 789]);
@@ -36,13 +36,13 @@
 //! ## The Problem with `None`
 //!
 //! Any place where a [`FieldValue`] is accepted, it's expected you'll also be
-//! able to pass a `None`, per the Shotgun Python API's conventions.
+//! able to pass a `None`, per the ShotGrid Python API's conventions.
 //!
 //! In Rust, this can cause *type inference problems* in cases where you want to
 //! write filters in the same style as you might with the Python API:
 //!
 //! ```compile_fail
-//! use shotgun_rs::filters::field;
+//! use shotgrid_rs::filters::field;
 //!
 //! field("due_date").is(None); // Won't work!
 //! field("entity.Asset.id").in_(&[1, 2, 3, None]); // Also won't work!
@@ -91,7 +91,7 @@
 //! that can convert to [`FieldValue`] will work):
 //!
 //! ```
-//! use shotgun_rs::filters::field;
+//! use shotgrid_rs::filters::field;
 //!
 //! // Arbitrarily say the Option is T=&str.
 //! field("due_date").is(Option::<&str>::None);
@@ -101,7 +101,7 @@
 //! value, *not framed in terms of some other type* (like it is in Python).
 //!
 //! ```
-//! use shotgun_rs::filters::{field, FieldValue};
+//! use shotgrid_rs::filters::{field, FieldValue};
 //!
 //! field("due_date").is(FieldValue::None);
 //! ```
@@ -113,7 +113,7 @@
 //! and also there's an Option in there*), you can rewrite in terms of `Option<i32>`:
 //!
 //! ```
-//! use shotgun_rs::filters::field;
+//! use shotgrid_rs::filters::field;
 //!
 //! // All items are Option<i32>, so it works!
 //! field("entity.Asset.id").in_(&[Some(1), Some(2), Some(3), None]);
@@ -125,7 +125,7 @@
 //! filters* created using the [`field()`] function.
 //!
 //! ```
-//! use shotgun_rs::filters::{self, field, EntityRef};
+//! use shotgrid_rs::filters::{self, field, EntityRef};
 //!
 //! let task_filters = filters::basic(&[
 //!     field("due_date").in_calendar_month(0),
@@ -157,7 +157,7 @@
 //! [`field()`].
 //!
 //! ```
-//! use shotgun_rs::filters::{self, field, FieldValue};
+//! use shotgrid_rs::filters::{self, field, FieldValue};
 //!
 //! // Find tasks that either have
 //! // - a due date but no assignee, or
@@ -201,7 +201,7 @@
 //! `.into()`.
 //!
 //! ```
-//! use shotgun_rs::filters::{self, field};
+//! use shotgrid_rs::filters::{self, field};
 //!
 //! let approved_ensemble = filters::complex(
 //!     filters::and(&[
@@ -224,10 +224,10 @@
 //!
 //! # See Also
 //!
-//! For more on filtering Shotgun queries:
+//! For more on filtering ShotGrid queries:
 //!
-//! - <https://developer.shotgunsoftware.com/rest-api/#filtering>
-//! - <https://developer.shotgunsoftware.com/python-api/reference.html#filter-syntax>
+//! - <https://developer.shotgridsoftware.com/rest-api/#filtering>
+//! - <https://developer.shotgridsoftware.com/python-api/reference.html#filter-syntax>
 
 use serde::{
     ser::{SerializeMap, SerializeSeq},
@@ -352,7 +352,7 @@ impl Serialize for LogicalFilterOperator {
 /// This is useful for writing filters for multi-entity link fields.
 ///
 /// ```
-/// use shotgun_rs::filters::{self, field, EntityRef};
+/// use shotgrid_rs::filters::{self, field, EntityRef};
 ///
 /// field("entity").in_(&[
 ///     EntityRef::new("Shot", 123),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -10,7 +10,7 @@ pub struct SchemaFieldProperties {
     pub summary_default: Option<SchemaResponseValue>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/?shell#tocSschemafieldrecord>
+/// <https://developer.shotgridsoftware.com/rest-api/?shell#tocSschemafieldrecord>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SchemaFieldRecord {
     pub custom_metadata: Option<SchemaResponseValue>,
@@ -26,27 +26,27 @@ pub struct SchemaFieldRecord {
     pub visible: Option<SchemaResponseValue>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/?shell#tocSschemafieldresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/?shell#tocSschemafieldresponse>
 pub type SchemaFieldResponse = SingleResourceResponse<SchemaFieldRecord, SelfLink>;
 
-/// <https://developer.shotgunsoftware.com/rest-api/?shell#tocSschemafieldsresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/?shell#tocSschemafieldsresponse>
 pub type SchemaFieldsResponse =
     SingleResourceResponse<HashMap<String, SchemaFieldRecord>, SelfLink>;
 
-/// <https://developer.shotgunsoftware.com/rest-api/?shell#schemaschemaentityrecord>
+/// <https://developer.shotgridsoftware.com/rest-api/?shell#schemaschemaentityrecord>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SchemaEntityRecord {
     pub name: Option<SchemaResponseValue>,
     pub visible: Option<SchemaResponseValue>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/?shell#tocSschemaentityresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/?shell#tocSschemaentityresponse>
 pub type SchemaEntityResponse = SingleResourceResponse<SchemaEntityRecord, SelfLink>;
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSschemaentitiesresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSschemaentitiesresponse>
 pub type SchemaEntitiesResponse = ResourceMapResponse<SchemaEntityRecord, SelfLink>;
 
-/// <https://developer.shotgunsoftware.com/rest-api/?shell#schemaschemaresponsevalue>
+/// <https://developer.shotgridsoftware.com/rest-api/?shell#schemaschemaresponsevalue>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SchemaResponseValue {
     /// Can be a string or a boolean
@@ -97,14 +97,14 @@ pub enum FieldDataType {
     Calculated,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocScreatefieldrequest>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocScreatefieldrequest>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CreateFieldRequest {
     pub data_type: FieldDataType,
     pub properties: Vec<CreateUpdateFieldProperty>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocScreateupdatefieldproperty>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocScreateupdatefieldproperty>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CreateUpdateFieldProperty {
     pub property_name: String,
@@ -137,7 +137,7 @@ where
     }
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSupdatefieldrequest>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSupdatefieldrequest>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UpdateFieldRequest {
     pub properties: Vec<CreateUpdateFieldProperty>,

--- a/src/search.rs
+++ b/src/search.rs
@@ -93,10 +93,10 @@ impl<'a> SearchBuilder<'a> {
             }
 
             // The page size is optional so we don't have to hard code
-            // shotgun's *current* default of 500 into the library.
+            // ShotGrid's *current* default of 500 into the library.
             //
-            // If/when shotgun changes their default, folks who haven't
-            // specified a page size should get whatever shotgun says, not *our*
+            // If/when ShotGrid changes their default, folks who haven't
+            // specified a page size should get whatever ShotGrid says, not *our*
             // hard-coded default.
             if let Some(size) = pag.size {
                 query.push(("page[size]", Cow::Owned(format!("{}", size))));
@@ -126,7 +126,7 @@ impl<'a> SearchBuilder<'a> {
         }
         let (sg, token) = self.session.get_sg().await?;
         let req = sg
-            .client
+            .http
             .post(&format!(
                 "{}/api/v1/entity/{}/_search",
                 sg.sg_server, self.entity
@@ -135,10 +135,10 @@ impl<'a> SearchBuilder<'a> {
             .header("Accept", "application/json")
             .bearer_auth(&token)
             .header("Content-Type", self.filters.get_mime())
-            // XXX: the content type is being set to shotgun's custom mime types
-            //   to indicate the shape of the filter payload. Do not be tempted to use
-            //   `.json()` here instead of `.body()` or you'll end up reverting the
-            //   header set above.
+            // The content type is being set to ShotGrid's custom mime types
+            // to indicate the shape of the filter payload. Do not be tempted to
+            // use `.json()` here instead of `.body()` or you'll end up
+            // reverting the header set above.
             .body(json!({"filters": self.filters}).to_string());
 
         crate::handle_response(req.send().await?).await

--- a/src/summarize.rs
+++ b/src/summarize.rs
@@ -55,7 +55,7 @@ pub struct SummaryData {
     pub groups: Option<Vec<SummaryGroups>>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSsummarizeresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSsummarizeresponse>
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct SummarizeResponse {
     pub data: SummaryData,
@@ -68,25 +68,25 @@ pub struct SummarizeResponse {
 /// `(AsRef<str>, SummmaryFieldType)`.
 ///
 /// ```
-/// use shotgun_rs::types::SummaryField;
+/// use shotgrid_rs::types::SummaryField;
 ///
-/// # fn main() -> shotgun_rs::Result<()> {
-/// use shotgun_rs::types::SummaryFieldType;
+/// # fn main() -> shotgrid_rs::Result<()> {
+/// use shotgrid_rs::types::SummaryFieldType;
 /// let id_count = SummaryField::from(("id", SummaryFieldType::Count));
 /// let max_due_date: SummaryField = ("due_date", SummaryFieldType::Max).into();
 /// # Ok(())
 /// # }
 /// ```
 ///
-/// When making a call to `Shotgun::summarize()` you may want several
+/// When making a call to [`Session::summarize()`] you may want several
 /// `SummaryField` instances.
 /// For this you can convert a Vec of pairs into a `Vec<SummaryField>` by
 /// doing something like:
 ///
 /// ```
-/// use shotgun_rs::types::{SummaryField, SummaryFieldType};
+/// use shotgrid_rs::types::{SummaryField, SummaryFieldType};
 ///
-/// # fn main() -> shotgun_rs::Result<()> {
+/// # fn main() -> shotgrid_rs::Result<()> {
 /// let summary_fields: Vec<SummaryField> = vec![
 ///     ("id", SummaryFieldType::Count),
 ///     ("due_date", SummaryFieldType::Max),
@@ -173,7 +173,7 @@ pub struct SummaryOptions {
 /// grouping.
 ///
 /// ```
-/// use shotgun_rs::types::{Grouping, GroupingType, GroupingDirection};
+/// use shotgrid_rs::types::{Grouping, GroupingType, GroupingDirection};
 ///
 /// // For 3 element tuples, GroupingDirection can be an "implicit" Option:
 /// // `GroupingDirection::Desc` is the same as `Some(GroupingDirection::Desc)`
@@ -357,7 +357,7 @@ impl<'a> SummarizeReqBuilder<'a> {
         let (sg, token) = self.session.get_sg().await?;
 
         let req = sg
-            .client
+            .http
             .post(&format!(
                 "{}/api/v1/entity/{}/_summarize",
                 sg.sg_server, self.entity
@@ -365,10 +365,10 @@ impl<'a> SummarizeReqBuilder<'a> {
             .header("Accept", "application/json")
             .bearer_auth(token)
             .header("Content-Type", content_type)
-            // XXX: the content type is being set to shotgun's custom mime types
-            //   to indicate the shape of the filter payload. Do not be tempted to use
-            //   `.json()` here instead of `.body()` or you'll end up reverting the
-            //   header set above.
+            // The content type is being set to ShotGrid's custom mime types
+            // to indicate the shape of the filter payload. Do not be tempted to
+            // use `.json()` here instead of `.body()` or you'll end up
+            // reverting the header set above.
             .body(json!(body).to_string());
         handle_response(req.send().await?).await
     }

--- a/src/text_search.rs
+++ b/src/text_search.rs
@@ -103,7 +103,7 @@ impl<'a> TextSearchBuilder<'a> {
 
         let (sg, token) = self.session.get_sg().await?;
         let req = sg
-            .client
+            .http
             .post(&format!("{}/api/v1/entity/_text_search", sg.sg_server))
             .header("Content-Type", content_type)
             .header("Accept", "application/json")
@@ -177,7 +177,7 @@ mod tests {
         let result = get_entity_filters_mime(&filters);
         match result {
             Err(Error::InvalidFilters) => assert!(true),
-            _ => assert!(false, "Expected ShotgunError::InvalidFilters"),
+            _ => assert!(false, "Expected Error::InvalidFilters"),
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,7 +10,7 @@ pub use crate::summarize::{
 use serde_json::Value;
 use std::collections::HashMap;
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSactivityupdate>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSactivityupdate>
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ActivityUpdate {
     id: Option<i32>,
@@ -30,19 +30,19 @@ pub enum AltImages {
     Thumbnail,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/?shell#tocSbatchcreateoptionsparameter>
+/// <https://developer.shotgridsoftware.com/rest-api/?shell#tocSbatchcreateoptionsparameter>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BatchCreateOptionsParameter {
     pub options: Option<serde_json::Map<String, Value>>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSbatchedrequestsresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSbatchedrequestsresponse>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BatchedRequestsResponse {
     pub data: Option<Vec<Record>>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSclientcredentialsrequest>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSclientcredentialsrequest>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ClientCredentialsRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -78,7 +78,7 @@ impl Entity {
     }
 }
 
-/// EntityActivityStreamData is not represented as a named schema in the Shotgun OpenAPI Spec.
+/// EntityActivityStreamData is not represented as a named schema in the ShotGrid OpenAPI Spec.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EntityActivityStreamData {
     pub entity_id: Option<i32>,
@@ -88,7 +88,7 @@ pub struct EntityActivityStreamData {
     pub updates: Option<Vec<ActivityUpdate>>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSentityactivitystreamresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSentityactivitystreamresponse>
 pub type EntityActivityStreamResponse = SingleResourceResponse<EntityActivityStreamData, SelfLink>;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -97,7 +97,7 @@ pub struct EntityIdentifier {
     pub entity: Option<String>,
 }
 
-/// EntityThreadContentsData is not represented as a named schema in the Shotgun OpenAPI Spec.
+/// EntityThreadContentsData is not represented as a named schema in the ShotGrid OpenAPI Spec.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EntityThreadContentsData {
     pub id: Option<i32>,
@@ -106,7 +106,7 @@ pub struct EntityThreadContentsData {
     pub created_at: Option<String>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSentitythreadcontentsresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSentitythreadcontentsresponse>
 pub type EntityThreadContentsResponse = SingleResourceResponse<EntityThreadContentsData, SelfLink>;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -125,10 +125,10 @@ pub struct ErrorObject {
     pub meta: Option<serde_json::Map<String, Value>>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/?shell#tocSfieldhashresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/?shell#tocSfieldhashresponse>
 pub type FieldHashResponse = SingleResourceResponse<Value, SelfLink>;
 
-/// <https://developer.shotgunsoftware.com/rest-api/?shell#tocSfilterhash>
+/// <https://developer.shotgridsoftware.com/rest-api/?shell#tocSfilterhash>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FilterHash {
     pub logical_operator: Option<LogicalOperator>,
@@ -136,7 +136,7 @@ pub struct FilterHash {
     pub conditions: Option<Value>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSfollowerrecord>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSfollowerrecord>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FollowerRecord {
     pub id: Option<i32>,
@@ -145,7 +145,7 @@ pub struct FollowerRecord {
     pub links: Option<SelfLink>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSfollowrecord>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSfollowrecord>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FollowRecord {
     pub id: Option<i32>,
@@ -153,10 +153,10 @@ pub struct FollowRecord {
     pub links: Option<SelfLink>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSgetworkdayrulesresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSgetworkdayrulesresponse>
 pub type GetWorkDayRulesResponse = ResourceArrayResponse<WorkDayRulesData, SelfLink>;
 
-/// HierarchyEntityFields is not represented as a named schema in the Shotgun OpenAPI Spec.
+/// HierarchyEntityFields is not represented as a named schema in the ShotGrid OpenAPI Spec.
 // FIXME: the spec indicates `entity` and `fields` are optional, but if you send
 //  a `HierarchyEntityFields` to the server without either of them, you'll get a
 //  400 response.
@@ -167,7 +167,7 @@ pub struct HierarchyEntityFields {
     pub fields: Option<Vec<String>>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocShierarchyexpandrequest>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocShierarchyexpandrequest>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HierarchyExpandRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -238,13 +238,13 @@ pub struct HierarchyExpandResponseData {
     pub children: Option<Vec<HierarchyExpandResponseData>>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocShierarchyexpandresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocShierarchyexpandresponse>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HierarchyExpandResponse {
     pub data: Option<HierarchyExpandResponseData>,
 }
 
-/// HierarchyReferenceEntity is not represented as a named schema in the Shotgun OpenAPI Spec.
+/// HierarchyReferenceEntity is not represented as a named schema in the ShotGrid OpenAPI Spec.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HierarchyReferenceEntity {
     pub id: Option<i32>,
@@ -260,7 +260,7 @@ pub enum HierarchySearchCriteria {
     Entity(Entity),
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocShierarchysearchrequest>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocShierarchysearchrequest>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HierarchySearchRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -270,7 +270,7 @@ pub struct HierarchySearchRequest {
     pub seed_entity_field: Option<String>,
 }
 
-/// HierarchySearchResponseData is not represented as a named schema in the Shotgun OpenAPI Spec.
+/// HierarchySearchResponseData is not represented as a named schema in the ShotGrid OpenAPI Spec.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HierarchySearchResponseData {
     pub label: Option<String>,
@@ -280,7 +280,7 @@ pub struct HierarchySearchResponseData {
     pub project_id: Option<i32>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocShierarchysearchresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocShierarchysearchresponse>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HierarchySearchResponse {
     pub data: Option<Vec<HierarchySearchResponseData>>,
@@ -294,7 +294,7 @@ pub enum LogicalOperator {
     Or,
 }
 
-/// MultipleResourceResponse is not represented as a named schema in the Shotgun OpenAPI Spec.
+/// MultipleResourceResponse is not represented as a named schema in the ShotGrid OpenAPI Spec.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ResourceArrayResponse<R, L> {
     /// Resource data
@@ -312,7 +312,7 @@ pub struct ResourceMapResponse<R, L> {
     pub links: Option<L>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSoptionsparameter>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSoptionsparameter>
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct OptionsParameter {
     pub return_only: Option<ReturnOnly>,
@@ -320,13 +320,13 @@ pub struct OptionsParameter {
 }
 
 /// This controls the paging of search-style list API calls.
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSpaginationparameter>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSpaginationparameter>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PaginationParameter {
     ///  Pages start at 1, not 0.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub number: Option<usize>,
-    /// Shotgun's default currently is 500
+    /// ShotGrid's default currently is 500
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<usize>,
 }
@@ -340,7 +340,7 @@ impl Default for PaginationParameter {
     }
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSpaginationlinks>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSpaginationlinks>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PaginationLinks {
     // Has to rename because we can't do raw self
@@ -352,7 +352,7 @@ pub struct PaginationLinks {
 
 pub type PaginatedRecordResponse = ResourceArrayResponse<Record, PaginationLinks>;
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSpasswordrequest>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSpasswordrequest>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PasswordRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -373,10 +373,10 @@ impl Default for PasswordRequest {
     }
 }
 
-/// This does not exist as a part of Shotgun's REST API
+/// This does not exist as a part of ShotGrid's REST API
 pub type ProjectAccessUpdateResponse = SingleResourceResponse<Entity, SelfLink>;
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSrecord>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSrecord>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Record {
     pub id: Option<i32>,
@@ -386,7 +386,7 @@ pub struct Record {
     pub links: Option<SelfLink>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSrefreshrequest>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSrefreshrequest>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RefreshRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -395,7 +395,7 @@ pub struct RefreshRequest {
     pub refresh_token: Option<String>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/?shell#tocSrelationshipsresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/?shell#tocSrelationshipsresponse>
 /// The value is either a Record or a vec of records
 pub type RelationshipsResponse = SingleResourceResponse<Value, SelfLink>;
 
@@ -405,28 +405,28 @@ pub enum ReturnOnly {
     Retired,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/?shell#tocSsearchrequest>
+/// <https://developer.shotgridsoftware.com/rest-api/?shell#tocSsearchrequest>
 #[derive(Clone, Debug, Serialize)]
 pub struct SearchRequest {
     /// Either an array of arrays or a FilterHash
     pub filters: Option<crate::filters::FinalizedFilters>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSselflink>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSselflink>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SelfLink {
     #[serde(rename = "self")]
     pub self_link: Option<String>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSsinglerecordresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSsinglerecordresponse>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SingleRecordResponse {
     pub data: Option<Record>,
     pub links: Option<SelfLink>,
 }
 
-/// Unlike SingleRecordResponse, this is not part of Shotgun's REST API.
+/// Unlike SingleRecordResponse, this is not part of ShotGrid's REST API.
 /// This is a generic.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SingleResourceResponse<R, L> {
@@ -436,7 +436,7 @@ pub struct SingleResourceResponse<R, L> {
     pub links: Option<L>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocStextsearchrequest>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocStextsearchrequest>
 #[derive(Serialize, Debug, Clone)]
 pub struct TextSearchRequest {
     pub entity_types: HashMap<String, crate::filters::FinalizedFilters>,
@@ -448,7 +448,7 @@ pub struct TextSearchRequest {
     pub sort: Option<String>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSupdateworkdayrulesrequest>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSupdateworkdayrulesrequest>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UpdateWorkDayRulesRequest {
     pub date: String,
@@ -463,7 +463,7 @@ pub struct UpdateWorkDayRulesRequest {
     pub description: Option<String>,
 }
 
-/// UpdateWorkDayRulesData is not represented as a named schema in the Shotgun OpenAPI Spec.
+/// UpdateWorkDayRulesData is not represented as a named schema in the ShotGrid OpenAPI Spec.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UpdateWorkDayRulesData {
     pub date: Option<String>,
@@ -472,10 +472,10 @@ pub struct UpdateWorkDayRulesData {
     pub reason: Option<String>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/?shell#tocSupdateworkdayrulesresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/?shell#tocSupdateworkdayrulesresponse>
 pub type UpdateWorkDayRulesResponse = SingleResourceResponse<UpdateWorkDayRulesData, SelfLink>;
 
-/// UploadInfoData is not represented as a named schema in the Shotgun OpenAPI Spec.
+/// UploadInfoData is not represented as a named schema in the ShotGrid OpenAPI Spec.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UploadInfoData {
     pub timestamp: Option<String>,
@@ -486,7 +486,7 @@ pub struct UploadInfoData {
     pub multipart_upload: Option<bool>,
 }
 
-/// UploadInfoLinks is not represented as a named schema in the Shotgun OpenAPI Spec.
+/// UploadInfoLinks is not represented as a named schema in the ShotGrid OpenAPI Spec.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UploadInfoLinks {
     pub upload: Option<String>,
@@ -504,26 +504,26 @@ pub(crate) struct NextUploadPartResponse {
     pub links: Option<NextUploadPartLinks>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSuploadinforesponse>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSuploadinforesponse>
 pub type UploadInfoResponse = SingleResourceResponse<UploadInfoData, UploadInfoLinks>;
 
-/// UploadResponseData is not represented as a named schema in the Shotgun OpenAPI Spec.
+/// UploadResponseData is not represented as a named schema in the ShotGrid OpenAPI Spec.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UploadResponseData {
     pub upload_id: Option<String>,
     pub original_filename: Option<String>,
 }
 
-/// UploadResponseLinks is not represented as a named schema in the Shotgun OpenAPI Spec.
+/// UploadResponseLinks is not represented as a named schema in the ShotGrid OpenAPI Spec.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UploadResponseLinks {
     pub complete_upload: Option<String>,
 }
 
-/// <https://developer.shotgunsoftware.com/rest-api/#tocSuploadresponse>
+/// <https://developer.shotgridsoftware.com/rest-api/#tocSuploadresponse>
 pub type UploadResponse = SingleResourceResponse<UploadResponseData, UploadResponseLinks>;
 
-/// WorkDayRulesData is not represented as a named schema in the Shotgun OpenAPI Spec.
+/// WorkDayRulesData is not represented as a named schema in the ShotGrid OpenAPI Spec.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct WorkDayRulesData {
     pub date: Option<String>,

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -3,8 +3,8 @@
 
 use futures::future;
 use serde_json::Value;
-use shotgun_rs::filters::{self, field};
-use shotgun_rs::{Session, Shotgun};
+use shotgrid_rs::filters::{self, field};
+use shotgrid_rs::{Client, Session};
 
 pub fn get_human_user_login() -> String {
     dotenv::dotenv().ok();
@@ -35,12 +35,12 @@ pub fn get_project_id() -> i32 {
         .expect("TEST_SG_PROJECT_ID")
 }
 
-pub fn get_test_client() -> Shotgun {
+pub fn get_test_client() -> Client {
     dotenv::dotenv().ok();
     let sg_server: String = std::env::var("TEST_SG_SERVER").expect("TEST_SG_SERVER");
     let sg_script_name: String = std::env::var("TEST_SG_SCRIPT_NAME").expect("TEST_SG_SCRIPT_NAME");
     let sg_script_key: String = std::env::var("TEST_SG_SCRIPT_KEY").expect("TEST_SG_SCRIPT_KEY");
-    Shotgun::new(sg_server, Some(&sg_script_name), Some(&sg_script_key)).expect("client init")
+    Client::new(sg_server, Some(&sg_script_name), Some(&sg_script_key)).expect("client init")
 }
 
 pub async fn get_api_user_id(sess: &Session<'_>) -> i32 {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "integration-tests")]
-//! The unfortunate thing for these tests that target an actual shotgun server
+//! The unfortunate thing for these tests that target an actual ShotGrid server
 //! is we can't really assert anything about the records in the database unless
 //! we create those records in the test itself (which we'd rather not do).
 //!
@@ -9,7 +9,7 @@
 //!
 //! These tests depend on several env vars being set.
 //!
-//! - `TEST_SG_SERVER`, the shotgun server to connect to.
+//! - `TEST_SG_SERVER`, the ShotGrid server to connect to.
 //! - `TEST_SG_SCRIPT_NAME`, the name of an ApiUser to connect as.
 //! - `TEST_SG_SCRIPT_KEY`, the API key to go with the name.
 //! - `TEST_SG_HUMAN_USER_LOGIN`, certain tests require a HumanUser so this is
@@ -17,8 +17,8 @@
 //! - `TEST_SG_PROJECT_ID`, some tests require a project to filter by.
 
 use serde_json::{json, Value};
-use shotgun_rs::filters::{self, field, EntityRef};
-use shotgun_rs::types::{
+use shotgrid_rs::filters::{self, field, EntityRef};
+use shotgrid_rs::types::{
     Entity, GroupingDirection, GroupingType, HierarchyEntityFields, HierarchyExpandRequest,
     HierarchySearchCriteria, HierarchySearchRequest, SummaryFieldType,
 };
@@ -203,7 +203,7 @@ async fn e2e_test_text_search() {
         // Text search only works for human users for some reason.
         // Using a "sudo as" user to get around the limitation for now.
         // <https://support.shotgunsoftware.com/hc/en-us/requests/114649>
-        // *(fixed in shotgun v8.16).*
+        // *(fixed in ShotGrid v8.16).*
         .authenticate_script_as_user(&login)
         .await
         .expect("Sudo As auth");
@@ -226,7 +226,7 @@ async fn e2e_test_text_search_empty_filters() {
         // Text search only works for human users for some reason.
         // Using a "sudo as" user to get around the limitation for now.
         // <https://support.shotgunsoftware.com/hc/en-us/requests/114649>
-        // *(fixed in shotgun v8.16).*
+        // *(fixed in ShotGrid v8.16).*
         .authenticate_script_as_user(&login)
         .await
         .expect("Sudo As auth");
@@ -270,7 +270,7 @@ async fn e2e_test_crud_kitchen_sink() {
         .create(
             "Note",
             json!({
-                "subject": "shotgun-rs test",
+                "subject": "shotgrid-rs test",
                 "content": "this is a test",
                 "project": { "type": "Project", "id": project_id }
             }),
@@ -330,7 +330,7 @@ async fn e2e_test_hierarchy_expand() {
 
     let data = HierarchyExpandRequest {
         // Not sure what I can pass as entity fields to change the
-        // response we get from shotgun, but at least the server accepts
+        // response we get from ShotGrid, but at least the server accepts
         // this payload. It just doesn't seem to have any effect.
         entity_fields: Some(vec![HierarchyEntityFields {
             entity: Some("Project".to_string()),


### PR DESCRIPTION
Autodesk have rebranded the product from _Shotgun_ to _ShotGrid_. To
reflect this, many objects and comments needed to be updated.

Not that I anticipate Autodesk will rename the product again (not in the
near-term anyway), the client object itself has been renamed from
`Shotgun` to `Client`, which in turn prompted a name change for the
`with_client()` method. This is now the `Client::with_transport()`
method (following the precedent set by the addition of the `transport`
module in #7).

Some notable exceptions to this, preventing an outright find/replace,
are URLs to the support site, mentions of old API details in the
Changelog and the custom mime-types used to represent filter data (which
seem to be keeping the old "shotgun" nomenclature.

Fixes #4.